### PR TITLE
✨ [Feat] 일기관련 뷰 네비게이션 연결 완료

### DIFF
--- a/emuda/src/Pages/DetailDiaryView/DetailDiaryView.jsx
+++ b/emuda/src/Pages/DetailDiaryView/DetailDiaryView.jsx
@@ -140,7 +140,7 @@ const DetailDiaryData = [
     id: 1,
     date: '2024.03.20',
     week: '수요일',
-    emotion: 'exciting',
+    emotion: 'happy',
     image:
       'https://images.unsplash.com/photo-1487383298905-ee8a6b373ff9?q=80&w=1470&auto=format&fit=crop&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHx8fA%3D%3D',
     content:

--- a/emuda/src/Pages/MusicCardView/MusicCardView.jsx
+++ b/emuda/src/Pages/MusicCardView/MusicCardView.jsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import Button from '../../components/Button/Button';
 import PlayListCell from '../../components/PlayListCell/PlayListCell';
 import '../../Fonts/Font.css';
@@ -140,6 +141,7 @@ const sampleData = [
 ];
 
 const MusicCardView = () => {
+  const navigate = useNavigate();
   const [playlistData1, setPlaylistData1] = useState([]);
   const [playlistData2, setPlaylistData2] = useState([]);
 
@@ -157,7 +159,7 @@ const MusicCardView = () => {
   }, []);
 
   const handleNext = () => {
-    console.log('완료 버튼 클릭됨');
+    navigate('/detail');
   };
 
   return (

--- a/emuda/src/Pages/SearchMusicView/SearchMusicView.jsx
+++ b/emuda/src/Pages/SearchMusicView/SearchMusicView.jsx
@@ -1,6 +1,7 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import { useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import AppBarInEditMode from '../../components/AppBarInEditMode/AppBarInEditMode';
 import Button from '../../components/Button/Button';
 import '../../Fonts/Font.css';
@@ -177,6 +178,7 @@ const sampleData = [
 ];
 
 const SearchMusicView = () => {
+  const navigate = useNavigate();
   const [searchTerm, setSearchTerm] = useState('');
   const [isComposing, setIsComposing] = useState(false);
   const [recentSearches, setRecentSearches] = useState([]);
@@ -261,6 +263,7 @@ const SearchMusicView = () => {
       selectedItems.map((id) => sampleData.find((data) => data.id === id))
     );
     console.log('선택된 개수:', selectedItems.length);
+    navigate('/write');
   };
 
   return (

--- a/emuda/src/Pages/SearchMusicView/SearchMusicView.jsx
+++ b/emuda/src/Pages/SearchMusicView/SearchMusicView.jsx
@@ -263,7 +263,7 @@ const SearchMusicView = () => {
       selectedItems.map((id) => sampleData.find((data) => data.id === id))
     );
     console.log('선택된 개수:', selectedItems.length);
-    navigate('/write');
+    navigate(-1);
   };
 
   return (

--- a/emuda/src/Pages/WriteDiaryView/WriteDiaryView.jsx
+++ b/emuda/src/Pages/WriteDiaryView/WriteDiaryView.jsx
@@ -253,7 +253,11 @@ const WriteDiaryView = () => {
   };
 
   const handleNext = () => {
-    console.log('다음 버튼 클릭됨');
+    if (location.pathname === '/edit') {
+      navigate('/detail');
+    } else if (location.pathname === '/write') {
+      navigate('/card');
+    }
   };
 
   return (

--- a/emuda/src/components/AppBarInViewMode/AppBarInViewMode.jsx
+++ b/emuda/src/components/AppBarInViewMode/AppBarInViewMode.jsx
@@ -1,8 +1,17 @@
 /** @jsxImportSource @emotion/react */
 import { css } from '@emotion/react';
 import { IoIosArrowBack, IoMdCreate, IoMdTrash } from 'react-icons/io';
+import { useNavigate } from 'react-router-dom';
 
 function AppBarInViewMode() {
+  const navigate = useNavigate();
+  const onClickDeleteBtn = () => {
+    navigate('/');
+  };
+  const onClickEditBtn = () => {
+    navigate('/edit');
+  };
+
   return (
     <div css={BarStyle}>
       <button css={ButtonStyle}>
@@ -10,10 +19,10 @@ function AppBarInViewMode() {
       </button>
       <div css={ButtonStyle}></div>
       <div css={MainStyle}>일기</div>
-      <button css={ButtonStyle}>
+      <button css={ButtonStyle} onClick={onClickDeleteBtn}>
         <IoMdTrash />
       </button>
-      <button css={ButtonStyle}>
+      <button css={ButtonStyle} onClick={onClickEditBtn}>
         <IoMdCreate />
       </button>
     </div>


### PR DESCRIPTION
#38

## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
  closed #38

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
-일기 관련 화면 간 이동 (navigation) 연결
- [x] 일기 상세 화면에서 edit button -> 일기 수정 화면 넘기기
- [x] 일기 상세 화면에서 delete button -> 홈 화면 넘기기
- [x] 일기 작성 화면에서 음악찾기 button -> SearchMusicView 넘기기
- [x] 일기 작성 화면에서 다음 button -> MusicCardView 넘기기
- [x] MusicCardView에서 다음 button -> 일기 상세 화면 넘기기
- [x] 일기 수정 화면 완료 button -> 일기 상세 화면 넘기기

## 📸 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->
https://github.com/SSU-RETURN/emuda-front/assets/109158284/0c1f1b08-04aa-4d50-855e-29f1f7de2c50


## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 -->
일기 감정 그래프 화면 생기면 중간에 아래 부분으로 수정필요
- [ ] 일기 작성 화면에서 다음 button -> 일기 감정 그래프 화면 넘기기
- [ ] 일기 감정 그래프에서 다음 button -> MusicCardView화면 넘기기
- [ ] MusicCardView에서 다음 button -> 일기 상세 화면 넘기기